### PR TITLE
Fix issue where the publisher was not reconnecting after connection to RabbitMQ is restored

### DIFF
--- a/src/Elders.Cronus.Transport.RabbitMQ/RabbitMqPublisher.cs
+++ b/src/Elders.Cronus.Transport.RabbitMQ/RabbitMqPublisher.cs
@@ -85,7 +85,7 @@ namespace Elders.Cronus.Transport.RabbitMQ
         private void Close()
         {
             publishModel?.Abort();
-            connection?.Abort();
+            connection?.Abort(5000);
 
             connection = null;
             publishModel = null;

--- a/src/Elders.Cronus.Transport.RabbitMQ/RabbitMqPublisher.cs
+++ b/src/Elders.Cronus.Transport.RabbitMQ/RabbitMqPublisher.cs
@@ -84,11 +84,14 @@ namespace Elders.Cronus.Transport.RabbitMQ
 
         private void Close()
         {
-            publishModel?.Abort();
-            connection?.Abort(5000);
+            lock (connectionFactory)
+            {
+                publishModel?.Abort();
+                connection?.Abort(5000);
 
-            connection = null;
-            publishModel = null;
+                connection = null;
+                publishModel = null;
+            }
         }
 
         public void Dispose()

--- a/src/Elders.Cronus.Transport.RabbitMQ/RabbitMqPublisher.cs
+++ b/src/Elders.Cronus.Transport.RabbitMQ/RabbitMqPublisher.cs
@@ -76,9 +76,14 @@ namespace Elders.Cronus.Transport.RabbitMQ
             }
         }
 
+        private void Stop()
+        {
+            Close();
+            stoped = true;
+        }
+
         private void Close()
         {
-            stoped = true;
             publishModel?.Abort();
             connection?.Abort();
 
@@ -88,7 +93,7 @@ namespace Elders.Cronus.Transport.RabbitMQ
 
         public void Dispose()
         {
-            Close();
+            Stop();
         }
     }
 }

--- a/src/Elders.Cronus.Transport.RabbitMQ/cronus.transport.rabbitmq.rn.md
+++ b/src/Elders.Cronus.Transport.RabbitMQ/cronus.transport.rabbitmq.rn.md
@@ -1,3 +1,6 @@
+#### 5.0.0-beta0006 - 17.07.2020
+* Fix issue where the publisher was not reconnecting after connection to RabbitMQ is restored
+
 #### 5.0.0-beta0005 - 09.07.2020
 * Fix virtual host creation when using multiple endpoints
 


### PR DESCRIPTION
The publisher was not reconnecting to RabbitMQ after connections was reestablished to the RabbitMQ instance.

When the publisher throws an exception we are no longer stopping it but only closing the connections and doing some garbage collection and when we try to publish a new message we are trying to connect to RabbitMQ again.

This can be tested in these steps:
1. Make sure that RabbitMQ is up by sending a message to it from the publisher
2. Stop the RabbitMQ instance to make sure that the publisher looses connection to it
3. Try to send a new message while the RabbitMQ instance is stopped (this should fail)
4. Start the RabbitMQ instance and wait for it to fully boot
5. Try to send a new message and this time the message should go to RabbitMQ successfully