### PR TITLE
Public events

### DIFF
--- a/src/Elders.Cronus.Transport.RabbitMQ/IRabbitMqOptions.cs
+++ b/src/Elders.Cronus.Transport.RabbitMQ/IRabbitMqOptions.cs
@@ -10,5 +10,7 @@
         string VHost { get; set; }
         string ApiAddress { get; set; }
         FederatedExchangeOptions FederatedExchange { get; set; }
+
+        IRabbitMqOptions GetOptionsFor(string boundedContext);
     }
 }

--- a/src/Elders.Cronus.Transport.RabbitMQ/PrivateRabbitMqPublisher.cs
+++ b/src/Elders.Cronus.Transport.RabbitMQ/PrivateRabbitMqPublisher.cs
@@ -6,7 +6,7 @@ namespace Elders.Cronus.Transport.RabbitMQ
     public class PrivateRabbitMqPublisher<TMessage> : RabbitMqPublisher<TMessage>
         where TMessage : IMessage
     {
-        public PrivateRabbitMqPublisher(ISerializer serializer, RabbitMqConnectionResolver connectionResolver, ITenantResolver<IMessage> tenantResolver, IOptionsMonitor<BoundedContext> boundedContext, BoundedContextRabbitMqNamer bcRabbitMqNamer)
+        public PrivateRabbitMqPublisher(ISerializer serializer, IRabbitMqConnectionResolver<RabbitMqOptions> connectionResolver, ITenantResolver<IMessage> tenantResolver, IOptionsMonitor<BoundedContext> boundedContext, BoundedContextRabbitMqNamer bcRabbitMqNamer)
             : base(serializer, connectionResolver, tenantResolver, boundedContext, bcRabbitMqNamer)
         {
         }

--- a/src/Elders.Cronus.Transport.RabbitMQ/PublicRabbitMqOptions.cs
+++ b/src/Elders.Cronus.Transport.RabbitMQ/PublicRabbitMqOptions.cs
@@ -22,6 +22,11 @@ namespace Elders.Cronus.Transport.RabbitMQ
 
         public FederatedExchangeOptions FederatedExchange { get; set; } = new FederatedExchangeOptions();
 
+        public IRabbitMqOptions GetOptionsFor(string boundedContext)
+        {
+            return this;
+        }
+
         public string GetUpstreamUri()
         {
             return string.Join(' ', AmqpTcpEndpoint.ParseMultiple(Server).Select(x => $"{x}/{VHost}"));

--- a/src/Elders.Cronus.Transport.RabbitMQ/PublicRabbitMqPublisher.cs
+++ b/src/Elders.Cronus.Transport.RabbitMQ/PublicRabbitMqPublisher.cs
@@ -5,7 +5,7 @@ namespace Elders.Cronus.Transport.RabbitMQ
 {
     public class PublicRabbitMqPublisher : RabbitMqPublisher<IPublicEvent>
     {
-        public PublicRabbitMqPublisher(ISerializer serializer, RabbitMqConnectionResolver connectionResolver, ITenantResolver<IMessage> tenantResolver, IOptionsMonitor<BoundedContext> boundedContext, PublicMessagesRabbitMqNamer publicRabbitMqNamer)
+        public PublicRabbitMqPublisher(ISerializer serializer, IRabbitMqConnectionResolver<PublicRabbitMqOptions> connectionResolver, ITenantResolver<IMessage> tenantResolver, IOptionsMonitor<BoundedContext> boundedContext, PublicMessagesRabbitMqNamer publicRabbitMqNamer)
             : base(serializer, connectionResolver, tenantResolver, boundedContext, publicRabbitMqNamer)
         {
 

--- a/src/Elders.Cronus.Transport.RabbitMQ/RabbitMqConnectionFactory.cs
+++ b/src/Elders.Cronus.Transport.RabbitMQ/RabbitMqConnectionFactory.cs
@@ -36,14 +36,13 @@ namespace Elders.Cronus.Transport.RabbitMQ
         }
     }
 
-    public class RabbitMqConnectionFactoryNew<TOptions> : ConnectionFactory
-        where TOptions : IRabbitMqOptions
+    public class RabbitMqConnectionFactoryNew : ConnectionFactory
     {
-        static readonly ILogger logger = CronusLogger.CreateLogger(typeof(RabbitMqConnectionFactoryNew<TOptions>));
+        static readonly ILogger logger = CronusLogger.CreateLogger(typeof(RabbitMqConnectionFactoryNew));
 
-        private readonly TOptions options;
+        private readonly IRabbitMqOptions options;
 
-        public RabbitMqConnectionFactoryNew(TOptions options)
+        public RabbitMqConnectionFactoryNew(IRabbitMqOptions options)
         {
             this.options = options;
             logger.Debug(() => "Loaded RabbitMQ options are {@Options}", options);

--- a/src/Elders.Cronus.Transport.RabbitMQ/RabbitMqOptions.cs
+++ b/src/Elders.Cronus.Transport.RabbitMQ/RabbitMqOptions.cs
@@ -34,7 +34,7 @@ namespace Elders.Cronus.Transport.RabbitMQ
 
         List<RabbitMqOptions> ExternalServices { get; set; }
 
-        public RabbitMqOptions GetOptionsFor(string boundedContext)
+        public IRabbitMqOptions GetOptionsFor(string boundedContext)
         {
             var fromCfg = ExternalServices?.Where(opt => opt.BoundedContext.Equals(boundedContext, System.StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
             if (fromCfg is null == false)

--- a/src/Elders.Cronus.Transport.RabbitMQ/RabbitMqPublisherDiscovery.cs
+++ b/src/Elders.Cronus.Transport.RabbitMQ/RabbitMqPublisherDiscovery.cs
@@ -15,7 +15,9 @@ namespace Elders.Cronus.Transport.RabbitMQ
 
         IEnumerable<DiscoveredModel> GetModels()
         {
-            yield return new DiscoveredModel(typeof(RabbitMqConnectionResolver), typeof(RabbitMqConnectionResolver), ServiceLifetime.Singleton);
+            yield return new DiscoveredModel(typeof(IRabbitMqConnectionResolver<>), typeof(RabbitMqConnectionResolver<>), ServiceLifetime.Singleton);
+            yield return new DiscoveredModel(typeof(RabbitMqConnectionResolver<>), typeof(RabbitMqConnectionResolver<>), ServiceLifetime.Singleton);
+
 
             yield return new DiscoveredModel(typeof(BoundedContextRabbitMqNamer), typeof(BoundedContextRabbitMqNamer), ServiceLifetime.Singleton);
             yield return new DiscoveredModel(typeof(PublicMessagesRabbitMqNamer), typeof(PublicMessagesRabbitMqNamer), ServiceLifetime.Singleton);

--- a/src/Elders.Cronus.Transport.RabbitMQ/cronus.transport.rabbitmq.rn.md
+++ b/src/Elders.Cronus.Transport.RabbitMQ/cronus.transport.rabbitmq.rn.md
@@ -1,3 +1,6 @@
+#### 6.2.1 - 11.11.2020
+* Fixes the Public EventPublisher
+
 #### 6.2.0 - 30.09.2020
 * Reworks the connection management per bounded context when publishing mesages
 


### PR DESCRIPTION
# Title
Fixes the PublicEventPublisher Options

## Related Issue 
No related described issue.

### Description
Currently, on the 6.2.0 version, the public event publisher was using the configurations of the private publisher. This stopped the services from being able to publish public events in the federated exchanges. With this pull request we separate the public options from the private ones in the connection factory.