### PR TITLE
Adds options for consumers count when starting the RPC (Cronus 9)

### DIFF
--- a/src/Elders.Cronus.Transport.RabbitMQ/RabbitMqConsumerOptions.cs
+++ b/src/Elders.Cronus.Transport.RabbitMQ/RabbitMqConsumerOptions.cs
@@ -12,6 +12,8 @@ namespace Elders.Cronus.Transport.RabbitMQ
 
         public int RpcTimeout { get; set; } = 10; // In seconds
 
+        public int RpcWorkersCount { get; set; } = 10;
+
         /// <summary>
         /// Drasticly changes the infrastructure behavior. This will create a separate queue per node and a message will be delivered to every node.
         /// </summary>

--- a/src/Elders.Cronus.Transport.RabbitMQ/RpcAPI/RequestConsumer.cs
+++ b/src/Elders.Cronus.Transport.RabbitMQ/RpcAPI/RequestConsumer.cs
@@ -25,7 +25,6 @@ namespace Elders.Cronus.Transport.RabbitMQ.RpcAPI
             model.QueueDeclare(queue, exclusive: false);
             model.BasicQos(0, 1, false);
             model.BasicConsume(queue, autoAck: false, this); // We should do manual acknowledgement to spread the load equally over multiple servers
-            logger.Info(() => $"RPC request consumer started for {queue}.");
         }
 
         protected override async Task DeliverMessageToSubscribersAsync(BasicDeliverEventArgs ev, AsyncEventingBasicConsumer consumer)

--- a/src/Elders.Cronus.Transport.RabbitMQ/RpcAPI/RpcEndpoint.cs
+++ b/src/Elders.Cronus.Transport.RabbitMQ/RpcAPI/RpcEndpoint.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading;
@@ -83,10 +82,12 @@ namespace Elders.Cronus.Transport.RabbitMQ.RpcAPI
             try
             {
                 IRabbitMqOptions scopedOptions = options.GetOptionsFor(boundedContext.Name);
-
                 IModel requestChannel = channelResolver.Resolve(route, scopedOptions, options.VHost);
 
-                server = new RequestConsumer<TRequest, TResponse>(route, requestChannel, factory, serializer, serviceProvider, logger);
+                for (int workerNumber = 0; workerNumber < consumerOptions.RpcWorkersCount; workerNumber++)
+                    server = new RequestConsumer<TRequest, TResponse>(route, requestChannel, factory, serializer, serviceProvider, logger);
+
+                logger.Info(() => $"{consumerOptions.RpcWorkersCount} RPC request consumers started for {route}.");
             }
             catch (Exception ex) when (logger.ErrorException(ex, () => $"Unable to start rpc server for {route}.")) { }
         }


### PR DESCRIPTION
With this configuration the RPC consumers count can be increased via a configuration so that it is no longer dependent only on the number of running instances of the service. This also means that if the configuration is set to 10 and there are 5 running instances there would be 50 consumers for each RPC request.